### PR TITLE
Type cast of char* to (size_t)* sometimes results in a negative number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 venv/
 .pytest_cache/
 .tox/
+.local/
 __pycache__/
 tests/fixtures/benchmarks/*
 

--- a/run
+++ b/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-versions="3.5 3.6 3.7 3.8 3.9 3.10 3.11"
+versions="3.5 3.6 3.7 3.8 3.9 3.10 3.11 3.12 3.13"
 
 function run_version_tests {
     if [ "--build" = $2 ]
@@ -50,7 +50,7 @@ function run_testrunner {
         for version in $versions
         do
             docker exec $container bash \
-                -c "python$version -m pip install numpy pytest"
+                -c "python$version -m pip install numpy pytest && python$version -m pip install -e /code"
         done
         docker exec $container bash \
             -c "python3.11 -m pip install tox"

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open("README.md", "r", encoding="utf-8") as f:
 
 setup(
     name="lazycsv",
-    version="1.1.6",
+    version="1.1.7",
     author="Michael Green, Chris Perkins",
     author_email="dev@crunch.io",
     description="an fast, memory efficient csv parser",
@@ -62,6 +62,8 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Utilities",
     ],

--- a/src/lazycsv/lazycsv.c
+++ b/src/lazycsv/lazycsv.c
@@ -122,15 +122,18 @@ typedef struct {
 } LazyCSV_Iter;
 
 
-static inline void LazyCSV_BufferWrite(int fd, LazyCSV_Buffer *buffer,
+static inline ssize_t LazyCSV_BufferWrite(int fd, LazyCSV_Buffer *buffer,
                                        void *data, size_t size) {
 
+    ssize_t bytes_written = 0;
+
     if (buffer->size + size >= buffer->capacity) {
-        write(fd, buffer->data, buffer->size);
+        bytes_written = write(fd, buffer->data, buffer->size);
         buffer->size = 0;
     }
     memcpy(&buffer->data[buffer->size], data, size);
     buffer->size += size;
+    return bytes_written;
 }
 
 
@@ -149,14 +152,19 @@ static inline void LazyCSV_BufferCache(LazyCSV_Buffer *buffer, void *data,
 }
 
 
-static inline void LazyCSV_BufferFlush(int comma_file, LazyCSV_Buffer *buffer) {
-    write(comma_file, buffer->data, buffer->size);
+static inline ssize_t LazyCSV_BufferFlush(int comma_file, LazyCSV_Buffer *buffer) {
+    ssize_t bytes_written = 0;
+    bytes_written = write(comma_file, buffer->data, buffer->size);
+    if (bytes_written < 0) {
+        return bytes_written;
+    }
     buffer->size = 0;
     fsync(comma_file);
+    return bytes_written;
 }
 
 
-static inline void LazyCSV_ValueToDisk(size_t value, LazyCSV_RowIndex *ridx,
+static inline ssize_t LazyCSV_ValueToDisk(size_t value, LazyCSV_RowIndex *ridx,
                                        LazyCSV_AnchorPoint *apnt,
                                        size_t col_index, int cfile,
                                        LazyCSV_Buffer *cbuf, int afile,
@@ -166,14 +174,16 @@ static inline void LazyCSV_ValueToDisk(size_t value, LazyCSV_RowIndex *ridx,
 
     if (target > INDEX_DTYPE_MAX) {
         *apnt = (LazyCSV_AnchorPoint){.value = value, .col = col_index+1};
-        LazyCSV_BufferWrite(afile, abuf, apnt, sizeof(LazyCSV_AnchorPoint));
+        ssize_t bytes_written = LazyCSV_BufferWrite(afile, abuf, apnt, sizeof(LazyCSV_AnchorPoint));
+        if (bytes_written < 0)
+            return bytes_written;
         ridx->count += 1;
         target = 0;
     }
 
     INDEX_DTYPE item = target;
 
-    LazyCSV_BufferWrite(cfile, cbuf, &item, sizeof(INDEX_DTYPE));
+    return LazyCSV_BufferWrite(cfile, cbuf, &item, sizeof(INDEX_DTYPE));
 }
 
 
@@ -305,7 +315,10 @@ static inline PyObject *PyBytes_FromOffsetAndLen(LazyCSV *lazy, size_t offset,
         break;
     case 1:
         addr = lazy->_data->data + offset;
-        result = lazy->_cache->items[(unsigned char)*addr];
+        unsigned char index = *addr; // explicit unsigned char for indexing purposes,
+                                     // *(char*) signed-ness is ambiguous and on some
+                                     // architectures it results in a negative number
+        result = lazy->_cache->items[index];
         Py_INCREF(result);
         break;
     default:
@@ -323,17 +336,17 @@ static inline PyObject *PyBytes_FromOffsetAndLen(LazyCSV *lazy, size_t offset,
         }
 
         result = PyBytes_FromStringAndSize(addr, len);
+
+        if (!result) {
+            PyErr_SetString(
+                PyExc_RuntimeError,
+                "could not allocate memory for new object"
+            );
+            return NULL;
+        }
     }
-    if (!result) goto failed_allocation;
 
     return result;
-
-failed_allocation:
-    PyErr_SetString(
-        PyExc_RuntimeError,
-        "could not allocate memory for new object"
-    );
-    return NULL;
 }
 
 
@@ -409,15 +422,16 @@ static PyObject* LazyCSV_IterAsList(PyObject* self) {
             LazyCSV_IterCol(iter, &offset, &len);
         }
         item = PyBytes_FromOffsetAndLen(lazy, offset, len);
-        if (!item) goto failed_allocation;
+        if (!item) {
+            // err msg set in PyBytes_FromOffsetAndLen,
+            // just need to decref the list here
+            Py_DECREF(result);
+            return item;
+        }
         PyList_SET_ITEM(result, i, item);
     }
 
     return result;
-
-failed_allocation:
-    Py_DECREF(result);
-    return NULL;
 }
 
 
@@ -617,6 +631,7 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
     int unquote = 1;
     Py_ssize_t buffer_capacity = 2097152; // 2**21
     char *dirname, *delimiter = ",", *quotechar = "\"";
+    ssize_t bytes_written = 0;
 
     static char* kwlist[] = {
         "", "delimiter", "quotechar", "skip_headers", "unquote", "buffer_size", "index_dir", NULL
@@ -658,9 +673,26 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
         return NULL;
     }
 
-    PyObject* fullname_obj;
-    char* fullname;
+    PyObject* fullname_obj = NULL;
+    char* fullname = NULL;
     LazyCSV_FullNameFromName(name, &fullname_obj, &fullname);
+
+    if (!fullname_obj) {
+        PyErr_SetString(
+            PyExc_MemoryError,
+            "unable to initialize filepath object"
+        );
+        return NULL;
+    }
+
+    if (!fullname) {
+        Py_XDECREF(fullname_obj);
+        PyErr_SetString(
+            PyExc_MemoryError,
+            "unable to determine file path from *PyObject"
+        );
+        return NULL;
+    }
 
     Py_DECREF(name);
 
@@ -672,7 +704,7 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
             " check to be sure that the user has read permissions"
             " and/or ownership of the file, and that the file exists."
         );
-        goto return_err;
+        return NULL;
     }
 
     struct stat ust;
@@ -701,8 +733,16 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
     int file_flags = O_WRONLY|O_CREAT|O_EXCL;
 
     int comma_file = open(comma_index, file_flags, S_IRWXU);
+    if (comma_file < 0)
+        goto close_comma_file;
+
     int anchor_file = open(anchor_index, file_flags, S_IRWXU);
+    if (anchor_file < 0)
+        goto close_anchor_file;
+
     int newline_file = open(newline_index, file_flags, S_IRWXU);
+    if (newline_file < 0)
+        goto close_newline_file;
 
     char quoted = 0, c, cm1 = LINE_FEED, cm2 = 0;
     size_t rows = 0, cols = SIZE_MAX, row_index = 0, col_index = 0;
@@ -757,8 +797,10 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
             ridx.index += ridx.count*sizeof(LazyCSV_AnchorPoint);
             ridx.count = 1;
 
-            LazyCSV_ValueToDisk(val, &ridx, &apnt, col_index, comma_file,
+            bytes_written = LazyCSV_ValueToDisk(val, &ridx, &apnt, col_index, comma_file,
                                 &comma_buffer, anchor_file, &anchor_buffer);
+            if (bytes_written < 0)
+                goto close_newline_file;
         }
 
         if (c == *quotechar) {
@@ -767,8 +809,10 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
 
         else if (!quoted && c == *delimiter) {
             size_t val = i + 1;
-            LazyCSV_ValueToDisk(val, &ridx, &apnt, col_index, comma_file,
+            bytes_written = LazyCSV_ValueToDisk(val, &ridx, &apnt, col_index, comma_file,
                                 &comma_buffer, anchor_file, &anchor_buffer);
+            if (bytes_written < 0)
+                goto close_newline_file;
             if (cols == SIZE_MAX || col_index < cols) {
                 col_index += 1;
             }
@@ -797,8 +841,10 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
             size_t val = i + 1;
 
             if (overflow == SIZE_MAX) {
-                LazyCSV_ValueToDisk(val, &ridx, &apnt, col_index, comma_file,
+                bytes_written = LazyCSV_ValueToDisk(val, &ridx, &apnt, col_index, comma_file,
                                     &comma_buffer, anchor_file, &anchor_buffer);
+                if (bytes_written < 0)
+                    goto close_newline_file;
             }
             else {
                 overflow = SIZE_MAX;
@@ -813,9 +859,11 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
                     "column underflow encountered while parsing CSV, "
                     "missing values will be filled with the empty bytestring!";
                 while (col_index < cols) {
-                  LazyCSV_ValueToDisk(val, &ridx, &apnt, col_index, comma_file,
+                    bytes_written = LazyCSV_ValueToDisk(val, &ridx, &apnt, col_index, comma_file,
                                       &comma_buffer, anchor_file,
                                       &anchor_buffer);
+                    if (bytes_written < 0)
+                        goto close_newline_file;
                   col_index += 1;
                 }
             }
@@ -841,11 +889,16 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
     char overcount = last_char == CARRIAGE_RETURN || last_char == LINE_FEED;
 
     if (!overcount) {
-        LazyCSV_ValueToDisk(file_len + 1, &ridx, &apnt, col_index, comma_file,
+        bytes_written = LazyCSV_ValueToDisk(file_len + 1, &ridx, &apnt, col_index, comma_file,
                             &comma_buffer, anchor_file, &anchor_buffer);
+        if (bytes_written < 0)
+            goto close_newline_file;
 
-        LazyCSV_BufferWrite(newline_file, &newline_buffer, &ridx,
+        bytes_written = LazyCSV_BufferWrite(newline_file, &newline_buffer, &ridx,
                             sizeof(LazyCSV_RowIndex));
+
+        if (bytes_written < 0)
+            goto close_newline_file;
     }
 
     if (overflow_warning)
@@ -865,9 +918,15 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
     rows = row_index - overcount + skip_headers;
     cols = cols + 1;
 
-    LazyCSV_BufferFlush(comma_file, &comma_buffer);
-    LazyCSV_BufferFlush(anchor_file, &anchor_buffer);
-    LazyCSV_BufferFlush(newline_file, &newline_buffer);
+    bytes_written = LazyCSV_BufferFlush(comma_file, &comma_buffer);
+    if (bytes_written < 0)
+        goto close_newline_file;
+    bytes_written = LazyCSV_BufferFlush(anchor_file, &anchor_buffer);
+    if (bytes_written < 0)
+        goto close_newline_file;
+    bytes_written = LazyCSV_BufferFlush(newline_file, &newline_buffer);
+    if (bytes_written < 0)
+        goto close_newline_file;
 
     close(comma_file);
     close(anchor_file);
@@ -877,42 +936,42 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
     free(anchor_buffer.data);
     free(newline_buffer.data);
 
-    int comma_fd = open(comma_index, O_RDWR);
+    comma_file = open(comma_index, O_RDWR);
     struct stat comma_st;
-    if (fstat(comma_fd, &comma_st) < 0) {
+    if (fstat(comma_file, &comma_st) < 0) {
         PyErr_SetString(
             PyExc_RuntimeError,
             "unable to stat comma file"
         );
-        goto close_comma;
+        goto close_comma_file;
     }
 
-    int anchor_fd = open(anchor_index, O_RDWR);
+    anchor_file = open(anchor_index, O_RDWR);
     struct stat anchor_st;
-    if (fstat(anchor_fd, &anchor_st) < 0) {
+    if (fstat(anchor_file, &anchor_st) < 0) {
         PyErr_SetString(
             PyExc_RuntimeError,
             "unable to stat anchor file"
         );
-        goto close_anchor;
+        goto close_anchor_file;
     }
 
-    int newline_fd = open(newline_index, O_RDWR);
+    newline_file = open(newline_index, O_RDWR);
     struct stat newline_st;
-    if (fstat(newline_fd, &newline_st) < 0) {
+    if (fstat(newline_file, &newline_st) < 0) {
         PyErr_SetString(
             PyExc_RuntimeError,
             "unable to stat newline file"
         );
-        goto close_newline;
+        goto close_newline_file;
     }
 
     char *comma_memmap =
-        mmap(NULL, comma_st.st_size, mmap_flags, MAP_PRIVATE, comma_fd, 0);
+        mmap(NULL, comma_st.st_size, mmap_flags, MAP_PRIVATE, comma_file, 0);
     char *anchor_memmap =
-        mmap(NULL, anchor_st.st_size, mmap_flags, MAP_PRIVATE, anchor_fd, 0);
+        mmap(NULL, anchor_st.st_size, mmap_flags, MAP_PRIVATE, anchor_file, 0);
     char *newline_memmap =
-        mmap(NULL, newline_st.st_size, mmap_flags, MAP_PRIVATE, newline_fd, 0);
+        mmap(NULL, newline_st.st_size, mmap_flags, MAP_PRIVATE, newline_file, 0);
 
     PyObject* headers;
 
@@ -962,28 +1021,28 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
 
     LazyCSV_Cache* _cache = malloc(sizeof(LazyCSV_Cache));
     _cache->empty = PyBytes_FromString("");
-    _cache->items = malloc(UCHAR_MAX*sizeof(PyObject*));
+    _cache->items = malloc((UCHAR_MAX+1)*sizeof(PyObject*));
 
-    for (unsigned char i = 0; i < UCHAR_MAX; i++)
+    for (size_t i = 0; i <= UCHAR_MAX; i++)
         _cache->items[i] = PyBytes_FromFormat("%c", (int)i);
 
     LazyCSV_File* _commas = malloc(sizeof(LazyCSV_File));
     _commas->name = comma_index;
     _commas->data = comma_memmap;
     _commas->st = comma_st;
-    _commas->fd = comma_fd;
+    _commas->fd = comma_file;
 
     LazyCSV_File* _anchors = malloc(sizeof(LazyCSV_File));
     _anchors->name = anchor_index;
     _anchors->data = anchor_memmap;
     _anchors->st = anchor_st;
-    _anchors->fd = anchor_fd;
+    _anchors->fd = anchor_file;
 
     LazyCSV_File* _newlines = malloc(sizeof(LazyCSV_File));
     _newlines->name = newline_index;
     _newlines->data = newline_memmap;
     _newlines->st = newline_st;
-    _newlines->fd = newline_fd;
+    _newlines->fd = newline_file;
 
     LazyCSV_Index* _index = malloc(sizeof(LazyCSV_Index));
 
@@ -1018,21 +1077,19 @@ unmap_memmaps:
     munmap(newline_memmap, newline_st.st_size);
     Py_DECREF(headers);
 
-close_newline:
-    close(newline_fd);
+close_newline_file:
+    close(newline_file);
 
-close_anchor:
-    close(anchor_fd);
+close_anchor_file:
+    close(anchor_file);
 
-close_comma:
-    close(comma_fd);
+close_comma_file:
+    close(comma_file);
     munmap(file, ust.st_size);
     Py_XDECREF(tempdir);
 
 close_ufd:
     close(ufd);
-
-return_err:
     return NULL;
 }
 
@@ -1063,7 +1120,7 @@ static void LazyCSV_Destruct(LazyCSV* self) {
     Py_XDECREF(self->_index->dir);
 
     Py_DECREF(self->_cache->empty);
-    for (size_t i = 0; i < UCHAR_MAX; i++)
+    for (size_t i = 0; i <= UCHAR_MAX; i++)
         Py_DECREF(self->_cache->items[i]);
     free(self->_cache->items);
 

--- a/src/lazycsv/lazycsv.c
+++ b/src/lazycsv/lazycsv.c
@@ -305,7 +305,7 @@ static inline PyObject *PyBytes_FromOffsetAndLen(LazyCSV *lazy, size_t offset,
         break;
     case 1:
         addr = lazy->_data->data + offset;
-        result = lazy->_cache->items[(size_t)*addr];
+        result = lazy->_cache->items[(unsigned char)*addr];
         Py_INCREF(result);
         break;
     default:
@@ -324,8 +324,16 @@ static inline PyObject *PyBytes_FromOffsetAndLen(LazyCSV *lazy, size_t offset,
 
         result = PyBytes_FromStringAndSize(addr, len);
     }
+    if (!result) goto failed_allocation;
 
     return result;
+
+failed_allocation:
+    PyErr_SetString(
+        PyExc_RuntimeError,
+        "could not allocate memory for new object"
+    );
+    return NULL;
 }
 
 
@@ -382,6 +390,13 @@ static PyObject* LazyCSV_IterAsList(PyObject* self) {
     }
 
     PyObject* result = PyList_New(size);
+    if (!result) {
+        PyErr_SetString(
+            PyExc_RuntimeError,
+            "could not allocate memory for new list"
+        );
+        return NULL;
+    }
     size_t offset=SIZE_MAX, len=0;
 
     PyObject* item;
@@ -394,10 +409,15 @@ static PyObject* LazyCSV_IterAsList(PyObject* self) {
             LazyCSV_IterCol(iter, &offset, &len);
         }
         item = PyBytes_FromOffsetAndLen(lazy, offset, len);
+        if (!item) goto failed_allocation;
         PyList_SET_ITEM(result, i, item);
     }
 
     return result;
+
+failed_allocation:
+    Py_DECREF(result);
+    return NULL;
 }
 
 
@@ -944,7 +964,7 @@ static PyObject *LazyCSV_New(PyTypeObject *type, PyObject *args,
     _cache->empty = PyBytes_FromString("");
     _cache->items = malloc(UCHAR_MAX*sizeof(PyObject*));
 
-    for (size_t i = 0; i < UCHAR_MAX; i++)
+    for (unsigned char i = 0; i < UCHAR_MAX; i++)
         _cache->items[i] = PyBytes_FromFormat("%c", (int)i);
 
     LazyCSV_File* _commas = malloc(sizeof(LazyCSV_File));

--- a/tests/benchmark_lazy.py
+++ b/tests/benchmark_lazy.py
@@ -172,9 +172,9 @@ def run_polars_scan(fpath):
 
 
 def main():
-    cols = 10000
-    rows = 100000
-    sparsity = 0.95
+    cols = 5000
+    rows = 50000
+    sparsity = 0.50
     benchmarks = {
         "lazycsv": run_lazy,
         # "pandas": run_pandas,
@@ -186,7 +186,9 @@ def main():
     }
     filename = f"benchmark_{rows}r_{cols}c_{int(sparsity*100)}%.csv"
     HERE = os.path.abspath(os.path.dirname(__file__))
-    filepath = os.path.join(HERE, f"fixtures/benchmarks/{filename}")
+    dir = os.path.join(HERE, f"fixtures/benchmarks")
+    os.makedirs(dir, exist_ok=True)
+    filepath = os.path.join(dir, filename)
     if os.path.isfile(filepath):
         name = filepath
         tempf = None

--- a/tests/script_lazycsv.py
+++ b/tests/script_lazycsv.py
@@ -1,3 +1,12 @@
+import sys
+
 from lazycsv import lazycsv
 
-lazy = lazycsv.LazyCSV("fixtures/file.csv")
+file = sys.argv[1]
+
+lazy = lazycsv.LazyCSV(file)
+
+data = [
+    list(lazy[:, i])
+    for i in range(lazy.cols)
+]

--- a/tests/script_lazycsv.py
+++ b/tests/script_lazycsv.py
@@ -10,3 +10,4 @@ data = [
     list(lazy[:, i])
     for i in range(lazy.cols)
 ]
+


### PR DESCRIPTION
The `_cache` attribute is an `len(256)` index of PyBytes objects which are localized for the purposes of fast returns. In the case that a csv field is `len(1)`, instead of calling the Python constructor `PyBytes_FromStringAndSize(*addr, 1)`, we can instead index into the cache and return the corresponding `PyObject*` for the character in the file.

Recently, we noticed in our kubernetes cluster that a csv file was failing to parse, and upon further investigation found that in that csv file there was particular field `\x85` that when being cast from `char*` to `(size_t)*` the result was -123. This is an invalid index value and as such the parser would Segmentation Fault. 

The fix in this case is to constrict the type definition of the cache and the associated indexing cast to `unsigned char`, so that casting from `char*` from the file to `(unsigned char)*` results in the correct index for the cache. 

This PR also includes more explicit `NULL` error checking for when PyObjects are created 
